### PR TITLE
Update py example (`Metadata` import)

### DIFF
--- a/py/__main__.py
+++ b/py/__main__.py
@@ -1,4 +1,4 @@
-from pulumi.provider.experimental import Metadata, component_provider_host
+from pulumi.provider.experimental import component_provider_host
 from staticpage import StaticPage
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove obsolete `Metadata` import, causing:

```
error: Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/eronwright/Pulumi/pulumi-hacking/pulumi/comp-as-comp/py/__main__.py", line 2, in <module>
    from pulumi.provider.experimental import Metadata, component_provider_host
ImportError: cannot import name 'Metadata' from 'pulumi.provider.experimental' (/Users/eronwright/Pulumi/pulumi-hacking/pulumi/comp-as-comp/py/venv/lib/python3.13/site-packages/pulumi/provider/experimental/__init__.py). Did you mean: 'metadata'?
```

See also: 
- https://github.com/pulumi/pulumi/pull/18985
- https://github.com/mikhailshilkov/comp-as-comp/pull/1