### PR TITLE
py component runtime options

### DIFF
--- a/py/PulumiPlugin.yaml
+++ b/py/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv


### PR DESCRIPTION
I believe the py component should use a venv, otherwise I see the following issues:

1. `pulumi package add ../py` errors out with a compilation issue to the effect that the component's venv isn't active.
2. The debugging experience fails because debugpy isn't found.